### PR TITLE
Add action field for special condition cards

### DIFF
--- a/actions/special_actions.php
+++ b/actions/special_actions.php
@@ -1,0 +1,6 @@
+<?php
+return [
+    // 'swap_cards' => function ($game) {
+    //     // TODO: Поменять игрокам карты
+    // },
+];

--- a/migrations/m250826_180000_add_action_to_card.php
+++ b/migrations/m250826_180000_add_action_to_card.php
@@ -1,0 +1,15 @@
+<?php
+use yii\db\Migration;
+
+class m250826_180000_add_action_to_card extends Migration
+{
+    public function safeUp()
+    {
+        $this->addColumn('{{%card}}', 'action', $this->string(32)->null()->after('text'));
+    }
+
+    public function safeDown()
+    {
+        $this->dropColumn('{{%card}}', 'action');
+    }
+}

--- a/models/Card.php
+++ b/models/Card.php
@@ -7,6 +7,7 @@ use yii\db\ActiveRecord;
  * @property int $id
  * @property int $type_id
  * @property string $text
+ * @property string|null $action
  * @property int $weight
  * @property string $status
  * @property int $created_at
@@ -22,6 +23,7 @@ class Card extends ActiveRecord
             [['type_id','text'], 'required'],
             [['type_id','weight','created_at','updated_at'], 'integer'],
             [['text'], 'string'],
+            [['action'], 'string', 'max' => 32],
             [['status'], 'in', 'range' => ['active','hidden','archived']],
         ];
     }

--- a/views/admin/card-form.php
+++ b/views/admin/card-form.php
@@ -17,6 +17,9 @@ $this->title = ($isNew ? 'Новая' : 'Редактирование') . ' ка
 
     <?php $form = ActiveForm::begin(); ?>
     <?= $form->field($model, 'text')->textarea(['rows'=>6]) ?>
+    <?php if ($type->code === 'SPECIAL'): ?>
+        <?= $form->field($model, 'action')->textInput(['maxlength'=>32]) ?>
+    <?php endif; ?>
     <?= $form->field($model, 'weight')->input('number', ['min'=>1, 'step'=>1]) ?>
     <?= $form->field($model, 'status')->dropDownList(['active'=>'active','hidden'=>'hidden','archived'=>'archived']) ?>
 

--- a/views/admin/cards.php
+++ b/views/admin/cards.php
@@ -46,6 +46,7 @@ $this->title = 'Карты: ' . $type->title;
                 'attribute' => 'text',
                 'format' => 'ntext',
             ],
+            'action',
             'weight',
             'status',
             [


### PR DESCRIPTION
## Summary
- add `action` column to cards and show field in admin for special card type
- list available special actions in new `actions/special_actions.php`

## Testing
- `./vendor/bin/codecept run`


------
https://chatgpt.com/codex/tasks/task_e_68aec9c1a558832cb6b503b5663ed767