### PR TITLE
feat: add revote special action

### DIFF
--- a/actions/special_actions.php
+++ b/actions/special_actions.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    'peregolosovanie' => function(\app\controllers\GameController $gc, \app\models\Game $game, \app\models\GameCard $card) {
+        if ($game->phase !== 'VOTE') return false;
+        $gc->pushEvent($game->id, 'vote_restart', ['round'=>$game->round_no]);
+        return true;
+    },
+];

--- a/controllers/GameController.php
+++ b/controllers/GameController.php
@@ -26,16 +26,17 @@ class GameController extends Controller
                     'start'      => ['POST'],
                     'finish'     => ['POST'],
                     'reveal'     => ['POST'],
-                    'eliminate'  => ['POST'],
-                    'board'      => ['GET'],
-                    'ping'       => ['GET'],
-                ],
-            ],
-        ];
+                      'eliminate'  => ['POST'],
+                      'special'    => ['POST'],
+                      'board'      => ['GET'],
+                      'ping'       => ['GET'],
+                  ],
+              ],
+          ];
     }
 
     /* ===== Служебные: события ===== */
-    private function pushEvent(int $gameId, string $type, array $payload = []): void
+    public function pushEvent(int $gameId, string $type, array $payload = []): void
     {
         $e = new GameEvent([
             'game_id'    => $gameId,
@@ -305,6 +306,38 @@ class GameController extends Controller
         return $this->redirect(['/game/' . $code]);
     }
 
+    public function actionSpecial($code, $card_id)
+    {
+        $code = strtoupper($code);
+        $game = Game::findOne(['code'=>$code]);
+        if (!$game || $game->status !== 'LIVE') return $this->redirect(['/game/' . $code]);
+
+        $me = $this->findCurrentPlayer($game);
+        if (!$me) return $this->redirect(['/game/' . $code]);
+
+        $card = GameCard::findOne([
+            'id' => (int)$card_id,
+            'game_id' => $game->id,
+            'player_id' => $me->id,
+            'type_code' => 'SPECIAL',
+        ]);
+        if (!$card || (int)$card->is_revealed === 1) return $this->redirect(['/game/' . $code]);
+
+        $actions = require Yii::getAlias('@app/actions/special_actions.php');
+        $handler = $actions[$card->action] ?? null;
+        if (is_callable($handler)) {
+            $res = $handler($this, $game, $card);
+            if ($res !== false) {
+                $card->is_public = 1;
+                $card->is_revealed = 1;
+                $card->revealed_at = time();
+                $card->save(false);
+            }
+        }
+
+        return $this->redirect(['/game/' . $code]);
+    }
+
     /* ===== Ход игры ===== */
     private function findCurrentPlayer(Game $game): ?GamePlayer
     {
@@ -509,17 +542,31 @@ class GameController extends Controller
         foreach ($players as $p) {
             foreach ($playerTypes as $t) {
                 $code = $t['code'];
-                if ($text = Card::pickTextByTypeCode($code)) {
+                if ($row = Card::pickOneByTypeCode($code)) {
                     (new GameCard([
                         'game_id'     => $gameId,
                         'player_id'   => $p->id,
                         'type_code'   => $code,
-                        'card_text'   => $text,
+                        'card_text'   => $row['text'],
+                        'action'      => $row['action'] ?? null,
                         'is_public'   => 0,
                         'is_revealed' => 0,
                         'created_at'  => $now,
                     ]))->save(false);
                 }
+            }
+            // Раздаём карту особого условия каждому игроку
+            if ($row = Card::pickOneByTypeCode('SPECIAL')) {
+                (new GameCard([
+                    'game_id'     => $gameId,
+                    'player_id'   => $p->id,
+                    'type_code'   => 'SPECIAL',
+                    'card_text'   => $row['text'],
+                    'action'      => $row['action'] ?? null,
+                    'is_public'   => 0,
+                    'is_revealed' => 0,
+                    'created_at'  => $now,
+                ]))->save(false);
             }
         }
     }

--- a/migrations/m250826_180000_add_action_to_card.php
+++ b/migrations/m250826_180000_add_action_to_card.php
@@ -1,0 +1,15 @@
+<?php
+use yii\db\Migration;
+
+class m250826_180000_add_action_to_card extends Migration
+{
+    public function safeUp()
+    {
+        $this->addColumn('{{%card}}', 'action', $this->string(32)->null()->after('text'));
+    }
+
+    public function safeDown()
+    {
+        $this->dropColumn('{{%card}}', 'action');
+    }
+}

--- a/migrations/m250827_190000_add_action_to_game_card.php
+++ b/migrations/m250827_190000_add_action_to_game_card.php
@@ -1,0 +1,15 @@
+<?php
+use yii\db\Migration;
+
+class m250827_190000_add_action_to_game_card extends Migration
+{
+    public function safeUp()
+    {
+        $this->addColumn('{{%game_card}}', 'action', $this->string(32)->null()->after('card_text'));
+    }
+
+    public function safeDown()
+    {
+        $this->dropColumn('{{%game_card}}', 'action');
+    }
+}

--- a/models/Card.php
+++ b/models/Card.php
@@ -7,6 +7,7 @@ use yii\db\ActiveRecord;
  * @property int $id
  * @property int $type_id
  * @property string $text
+ * @property string|null $action
  * @property int $weight
  * @property string $status
  * @property int $created_at
@@ -22,30 +23,39 @@ class Card extends ActiveRecord
             [['type_id','text'], 'required'],
             [['type_id','weight','created_at','updated_at'], 'integer'],
             [['text'], 'string'],
+            [['action'], 'string', 'max' => 32],
             [['status'], 'in', 'range' => ['active','hidden','archived']],
         ];
     }
 
     /**
-     * Выбирает случайную активную карту по коду типа с учётом веса.
-     * Возвращает текст карты (или null, если нет карт).
+     * Возвращает случайную активную карту по коду типа с учётом веса.
+     * Возвращает массив с ключами `text` и `action` (или null, если нет карт).
      */
-    public static function pickTextByTypeCode(string $typeCode): ?string
+    public static function pickOneByTypeCode(string $typeCode): ?array
     {
-        $row = (new \yii\db\Query())
+        $rows = (new \yii\db\Query())
             ->from('{{%card}} c')
             ->innerJoin('{{%card_type}} t', 't.id = c.type_id')
             ->where(['t.code' => $typeCode, 'c.status' => 'active', 't.status' => 'active'])
             ->all();
 
-        if (!$row) return null;
+        if (!$rows) return null;
 
-        // Взвешенный случайный выбор
         $pool = [];
-        foreach ($row as $r) {
+        foreach ($rows as $r) {
             $w = max(1, (int)$r['weight']);
-            for ($i=0; $i<$w; $i++) $pool[] = $r['text'];
+            for ($i=0; $i<$w; $i++) $pool[] = $r;
         }
         return $pool[random_int(0, count($pool)-1)];
+    }
+
+    /**
+     * Упрощённый вариант, возвращающий только текст карты (или null).
+     */
+    public static function pickTextByTypeCode(string $typeCode): ?string
+    {
+        $row = self::pickOneByTypeCode($typeCode);
+        return $row['text'] ?? null;
     }
 }

--- a/models/GameCard.php
+++ b/models/GameCard.php
@@ -11,6 +11,7 @@ use yii\db\ActiveRecord;
  * @property int|null $player_id
  * @property string $type_code
  * @property string $card_text
+ * @property string|null $action
  * @property int $is_public
  * @property int $is_revealed
  * @property int $created_at
@@ -27,6 +28,7 @@ class GameCard extends ActiveRecord
             [['game_id','player_id','created_at','revealed_at'], 'integer'],
             [['is_public','is_revealed'], 'boolean'],
             [['card_text'], 'string'],
+            [['action'], 'string', 'max' => 32],
             [['type_code'], 'string', 'max' => 32],
         ];
     }

--- a/views/admin/card-form.php
+++ b/views/admin/card-form.php
@@ -17,6 +17,9 @@ $this->title = ($isNew ? 'Новая' : 'Редактирование') . ' ка
 
     <?php $form = ActiveForm::begin(); ?>
     <?= $form->field($model, 'text')->textarea(['rows'=>6]) ?>
+    <?php if ($type->code === 'SPECIAL'): ?>
+        <?= $form->field($model, 'action')->textInput(['maxlength'=>32]) ?>
+    <?php endif; ?>
     <?= $form->field($model, 'weight')->input('number', ['min'=>1, 'step'=>1]) ?>
     <?= $form->field($model, 'status')->dropDownList(['active'=>'active','hidden'=>'hidden','archived'=>'archived']) ?>
 

--- a/views/admin/cards.php
+++ b/views/admin/cards.php
@@ -46,6 +46,7 @@ $this->title = 'Карты: ' . $type->title;
                 'attribute' => 'text',
                 'format' => 'ntext',
             ],
+            'action',
             'weight',
             'status',
             [

--- a/views/game/_board.php
+++ b/views/game/_board.php
@@ -174,35 +174,41 @@ $stripBunkerPrefix = function(string $text): string { return preg_replace('/^К�
                         $title = Html::encode($getTitle($c->type_code));
                         ?>
                         <div class="list-group-item d-flex justify-content-between align-items-start<?= $c->type_code==='THREAT' ? ' list-group-item-danger' : '' ?>">
-                            <div class="me-3">
-                                <div class="fw-bold <?= $titleCls ?>"><?= $title ?></div>
-                                <div><?= nl2br(Html::encode($c->card_text)) ?></div>
-                            </div>
+                              <div class="me-3">
+                                  <div class="fw-bold <?= $titleCls ?>"><?= $title ?></div>
+                                  <div><?= nl2br(Html::encode($c->card_text)) ?></div>
+                              </div>
 
-                            <?php
-                            $isMyTurn = ($game->phase==='DISCUSS') && $onMoveId && ((int)$onMoveId === (int)$current->id);
-                            $canRevealThis =
-                                $isMyTurn
-                                && !$revealed
-                                && (
-                                    ((int)$game->round_no === 1 && $c->type_code === 'PROFESSION')
-                                    || ((int)$game->round_no >= 2)
-                                );
-                            ?>
-                            <div class="text-end">
-                                <?php if ($canRevealThis): ?>
-                                    <form method="post" action="<?= Url::to(['/game/reveal', 'code' => $game->code, 'card_id' => $c->id]) ?>">
-                                        <?= Html::hiddenInput(Yii::$app->request->csrfParam, Yii::$app->request->getCsrfToken()) ?>
-                                        <button class="btn btn-sm btn-outline-primary">Открыть</button>
-                                    </form>
-                                <?php else: ?>
-                                    <button class="btn btn-sm btn-outline-secondary" disabled>Открыть</button>
-                                <?php endif; ?>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
+                              <?php
+                              $isMyTurn = ($game->phase==='DISCUSS') && $onMoveId && ((int)$onMoveId === (int)$current->id);
+                              $canRevealThis =
+                                  $isMyTurn
+                                  && !$revealed
+                                  && (
+                                      ((int)$game->round_no === 1 && $c->type_code === 'PROFESSION')
+                                      || ((int)$game->round_no >= 2)
+                                  );
+                              ?>
+                              <div class="text-end">
+                                  <?php if ($c->type_code === 'SPECIAL' && $c->action === 'peregolosovanie' && (int)$c->is_revealed !== 1 && $game->phase==='VOTE'): ?>
+                                      <form method="post" action="<?= Url::to(['/game/special', 'code' => $game->code, 'card_id' => $c->id]) ?>"
+                                            onsubmit="return confirm('Запустить новое голосование?');">
+                                          <?= Html::hiddenInput(Yii::$app->request->csrfParam, Yii::$app->request->getCsrfToken()) ?>
+                                          <button class="btn btn-sm btn-outline-danger">Переголосовать</button>
+                                      </form>
+                                  <?php elseif ($canRevealThis): ?>
+                                      <form method="post" action="<?= Url::to(['/game/reveal', 'code' => $game->code, 'card_id' => $c->id]) ?>">
+                                          <?= Html::hiddenInput(Yii::$app->request->csrfParam, Yii::$app->request->getCsrfToken()) ?>
+                                          <button class="btn btn-sm btn-outline-primary">Открыть</button>
+                                      </form>
+                                  <?php else: ?>
+                                      <button class="btn btn-sm btn-outline-secondary" disabled>Открыть</button>
+                                  <?php endif; ?>
+                              </div>
+                          </div>
+                      <?php endforeach; ?>
+                  </div>
+              <?php endif; ?>
 
             <?php if ($current->role === 'HOST'): ?>
                 <div class="mt-4 d-flex gap-2">


### PR DESCRIPTION
## Summary
- add "peregolosovanie" special card action to trigger new voting round
- snapshot card actions onto game cards and expose revote button during voting
- deal special cards to each player at game start

## Testing
- `./vendor/bin/codecept run`


------
https://chatgpt.com/codex/tasks/task_e_68aec9c1a558832cb6b503b5663ed767