### PR TITLE
feat: add diversia special card

### DIFF
--- a/migrations/m250828_210000_add_extra_threats_to_game.php
+++ b/migrations/m250828_210000_add_extra_threats_to_game.php
@@ -1,0 +1,15 @@
+<?php
+use yii\db\Migration;
+
+class m250828_210000_add_extra_threats_to_game extends Migration
+{
+    public function safeUp()
+    {
+        $this->addColumn('{{%game}}', 'extra_threats', $this->smallInteger()->notNull()->defaultValue(0));
+    }
+
+    public function safeDown()
+    {
+        $this->dropColumn('{{%game}}', 'extra_threats');
+    }
+}

--- a/migrations/m250828_220000_add_tainaya_ugroza_card.php
+++ b/migrations/m250828_220000_add_tainaya_ugroza_card.php
@@ -1,0 +1,30 @@
+<?php
+use yii\db\Migration;
+
+class m250828_220000_add_tainaya_ugroza_card extends Migration
+{
+    public function safeUp()
+    {
+        $typeId = (new \yii\db\Query())
+            ->from('{{%card_type}}')
+            ->select('id')
+            ->where(['code' => 'SPECIAL'])
+            ->scalar();
+        if ($typeId) {
+            $this->insert('{{%card}}', [
+                'type_id'   => $typeId,
+                'text'      => 'Особое условие: "Тайная угроза" — если вас изгоняют, в конце игры случайный игрок в бункере получит две карты угрозы.',
+                'action'    => 'tainaya-ugroza',
+                'weight'    => 1,
+                'status'    => 'active',
+                'created_at'=> time(),
+                'updated_at'=> time(),
+            ]);
+        }
+    }
+
+    public function safeDown()
+    {
+        $this->delete('{{%card}}', ['action' => 'tainaya-ugroza']);
+    }
+}

--- a/migrations/m250828_230000_add_diversia_card.php
+++ b/migrations/m250828_230000_add_diversia_card.php
@@ -1,0 +1,30 @@
+<?php
+use yii\db\Migration;
+
+class m250828_230000_add_diversia_card extends Migration
+{
+    public function safeUp()
+    {
+        $typeId = (new \yii\db\Query())
+            ->from('{{%card_type}}')
+            ->select('id')
+            ->where(['code' => 'SPECIAL'])
+            ->scalar();
+        if ($typeId) {
+            $this->insert('{{%card}}', [
+                'type_id'   => $typeId,
+                'text'      => 'Особое условие: "Диверсия" — если вас изгоняют, случайная открытая карта бункера исчезает.',
+                'action'    => 'diversia',
+                'weight'    => 1,
+                'status'    => 'active',
+                'created_at'=> time(),
+                'updated_at'=> time(),
+            ]);
+        }
+    }
+
+    public function safeDown()
+    {
+        $this->delete('{{%card}}', ['action' => 'diversia']);
+    }
+}

--- a/models/Game.php
+++ b/models/Game.php
@@ -20,6 +20,7 @@ use yii\db\ActiveRecord;
  * @property int|null $initial_player_count
  * @property string|null $voting_rounds
  * @property int|null $survivors_target
+ * @property int $extra_threats
  */
 class Game extends ActiveRecord
 {
@@ -40,6 +41,7 @@ class Game extends ActiveRecord
             [['code'], 'string', 'length' => 4],
             [['status','phase'], 'string', 'max' => 16],
             [['max_players','round_no','created_at','started_at','finished_at','current_turn_index','last_first_player_id','total_rounds','initial_player_count','survivors_target'], 'integer'],
+            [['extra_threats'], 'integer'],
             [['turn_order','voting_rounds'], 'string'],
         ];
     }


### PR DESCRIPTION
## Summary
- track pending threat penalties when a player with "Tainaya ugroza" is eliminated
- grant extra threat cards to random survivors at game end
- add migrations for secret threat card and game field
- hide random bunker card when eliminated player holds "Diversia"
- add migration for diversia special card

## Testing
- `composer install`
- `./vendor/bin/codecept run`


------
https://chatgpt.com/codex/tasks/task_e_68aed4849960832cbf9c9ed7c634778a