### PR TITLE
Add 'Davaite nachistotu' special cards

### DIFF
--- a/migrations/m250828_240000_add_davaite_nachistotu_cards.php
+++ b/migrations/m250828_240000_add_davaite_nachistotu_cards.php
@@ -1,0 +1,37 @@
+<?php
+use yii\db\Migration;
+
+class m250828_240000_add_davaite_nachistotu_cards extends Migration
+{
+    public function safeUp()
+    {
+        $typeId = (new \yii\db\Query())
+            ->from('{{%card_type}}')
+            ->select('id')
+            ->where(['code' => 'SPECIAL'])
+            ->scalar();
+        if ($typeId) {
+            $now = time();
+            $this->batchInsert('{{%card}}', ['type_id','text','action','weight','status','created_at','updated_at'], [
+                [$typeId, 'Особое условие: "Давайте начистоту — багаж" — перемешайте все открытые карты багажа между игроками.', 'davaite-nachistotu-bagazh', 1, 'active', $now, $now],
+                [$typeId, 'Особое условие: "Давайте начистоту — факты" — перемешайте все открытые карты фактов между игроками.', 'davaite-nachistotu-fakty', 1, 'active', $now, $now],
+                [$typeId, 'Особое условие: "Давайте начистоту — хобби" — перемешайте все открытые карты хобби между игроками.', 'davaite-nachistotu-hobbi', 1, 'active', $now, $now],
+                [$typeId, 'Особое условие: "Давайте начистоту — здоровье" — перемешайте все открытые карты здоровья между игроками.', 'davaite-nachistotu-zdorovie', 1, 'active', $now, $now],
+                [$typeId, 'Особое условие: "Давайте начистоту — биология" — перемешайте все открытые карты биологии между игроками.', 'davaite-nachistotu-biologia', 1, 'active', $now, $now],
+                [$typeId, 'Особое условие: "Давайте начистоту — фобия" — перемешайте все открытые карты фобии между игроками.', 'davaite-nachistotu-fobia', 1, 'active', $now, $now],
+            ]);
+        }
+    }
+
+    public function safeDown()
+    {
+        $this->delete('{{%card}}', ['action' => [
+            'davaite-nachistotu-bagazh',
+            'davaite-nachistotu-fakty',
+            'davaite-nachistotu-hobbi',
+            'davaite-nachistotu-zdorovie',
+            'davaite-nachistotu-biologia',
+            'davaite-nachistotu-fobia',
+        ]]);
+    }
+}

--- a/views/game/_board.php
+++ b/views/game/_board.php
@@ -211,6 +211,22 @@ $stripBunkerPrefix = function(string $text): string { return preg_replace('/^К�
                                         <?php else: ?>
                                             <button class="btn btn-sm btn-outline-secondary" disabled>Забрать багаж</button>
                                         <?php endif; ?>
+                                    <?php elseif ($c->type_code === 'SPECIAL' && in_array($c->action, [
+                                        'davaite-nachistotu-bagazh',
+                                        'davaite-nachistotu-fakty',
+                                        'davaite-nachistotu-hobbi',
+                                        'davaite-nachistotu-zdorovie',
+                                        'davaite-nachistotu-biologia',
+                                        'davaite-nachistotu-fobia',
+                                    ])): ?>
+                                        <?php if ((int)$c->is_revealed !== 1 && !$specialUsed): ?>
+                                            <form method="post" action="<?= Url::to(['/game/special', 'code' => $game->code, 'card_id' => $c->id]) ?>">
+                                                <?= Html::hiddenInput(Yii::$app->request->csrfParam, Yii::$app->request->getCsrfToken()) ?>
+                                                <button class="btn btn-sm btn-outline-danger">Перемешать</button>
+                                            </form>
+                                        <?php else: ?>
+                                            <button class="btn btn-sm btn-outline-secondary" disabled>Перемешать</button>
+                                        <?php endif; ?>
                                     <?php elseif ($canRevealThis): ?>
                                         <form method="post" action="<?= Url::to(['/game/reveal', 'code' => $game->code, 'card_id' => $c->id]) ?>">
                                             <?= Html::hiddenInput(Yii::$app->request->csrfParam, Yii::$app->request->getCsrfToken()) ?>


### PR DESCRIPTION
## Summary
- add six "Davaite nachistotu" special cards with shuffle effects
- implement server-side shuffle handlers for baggage, facts, hobby, health, biology and phobia
- show "Перемешать" button for these specials on the game board

## Testing
- `vendor/bin/codecept run`

------
https://chatgpt.com/codex/tasks/task_e_68aeda544b34832c8c4244225589bbbc